### PR TITLE
Fix: add json_encode flags in the infolists and replace references from activitylog to filament-activitylog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ### Spatie/Laravel-activitylog for Filament
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/filamerce/activitylog.svg?style=flat-square)](https://packagist.org/packages/filamerce/activitylog)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/filamerce/filament-activitylog.svg?style=flat-square)](https://packagist.org/packages/filamerce/filament-activitylog)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE.md)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/filamerce/activitylog/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/filamerce/activitylog/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
-[![Total Downloads](https://img.shields.io/packagist/dt/filamerce/activitylog.svg?style=flat-square)](https://packagist.org/packages/filamerce/activitylog/stats)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/filamerce/filament-activitylog/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/filamerce/filament-activitylog/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
+[![Total Downloads](https://img.shields.io/packagist/dt/filamerce/filament-activitylog.svg?style=flat-square)](https://packagist.org/packages/filamerce/filament-activitylog/stats)
 
 <div class="filament-hidden">
 
-![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/activitylog/main/arts/cover.jpeg)
+![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/filament-activitylog/main/arts/cover.jpeg)
 
 </div>
 
@@ -41,7 +41,7 @@ ActivityLog Plugin is translated for :
 You can install the package via composer:
 
 ```bash
-composer require filamerce/activitylog
+composer require filamerce/filament-activitylog
 ```
 
 After that run the install command:
@@ -119,7 +119,7 @@ class NewsItem extends Model
 
 ## Plugin usage
 
-![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/activitylog/main/arts/resource.png)
+![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/filament-activitylog/main/arts/resource.png)
 
 In your Panel ServiceProvider `(App\Providers\Filament)` active the plugin
 
@@ -325,7 +325,7 @@ public function panel(Panel $panel): Panel
 ## Relationship manager
 
 If you have a model that uses the `Spatie\Activitylog\Traits\LogsActivity` trait, you can add the `Rmsramos\Activitylog\RelationManagers\ActivitylogRelationManager` relationship manager to your Filament resource to display all of the activity logs that are performed on your model.
-![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/activitylog/main/arts/relationManager.png)
+![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/filament-activitylog/main/arts/relationManager.png)
 
 ```php
 use Rmsramos\Activitylog\RelationManagers\ActivitylogRelationManager;
@@ -340,7 +340,7 @@ public static function getRelations(): array
 
 ## Timeline Action
 
-![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/activitylog/main/arts/timeline.png)
+![Screenshot of Application Feature](https://raw.githubusercontent.com/filamerce/filament-activitylog/main/arts/timeline.png)
 
 To make viewing activity logs easier, you can use a custom action. In your UserResource in the table function, add the `ActivityLogTimelineTableAction`.
 

--- a/src/Infolists/Components/TimeLinePropertiesEntry.php
+++ b/src/Infolists/Components/TimeLinePropertiesEntry.php
@@ -58,7 +58,7 @@ class TimeLinePropertiesEntry extends Entry
         $changes = [];
 
         foreach ($newValues as $key => $newValue) {
-            $oldValue = is_array($oldValues[$key]) ? json_encode($oldValues[$key]) : $oldValues[$key] ?? '-';
+            $oldValue = is_array($oldValues[$key]) ? json_encode($oldValues[$key], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) : $oldValues[$key] ?? '-';
             $newValue = $this->formatNewValue($newValue);
 
             if (isset($oldValues[$key]) && $oldValues[$key] != $newValue) {
@@ -86,6 +86,6 @@ class TimeLinePropertiesEntry extends Entry
 
     private function formatNewValue($value): string
     {
-        return is_array($value) ? json_encode($value) : $value ?? '—';
+        return is_array($value) ? json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) : $value ?? '—';
     }
 }


### PR DESCRIPTION
## Summary
- Improve JSON encoding in the infolist timeline to unescaped unicode and slashes.
- Update all README links, badges, and install instructions to use filamerce/filament-activitylog.

In each error array string, correctly stored in the database, is unreadable because the original formatter does not use any flags to unescaped slashed and unicode.

### Data:
![image](https://github.com/user-attachments/assets/0fbe6aa5-877a-418a-b012-9139da4641f8)

### Before:
![image](https://github.com/user-attachments/assets/d174e3d5-3670-42a7-8052-e42d9127bf75)

### After:
![image](https://github.com/user-attachments/assets/a2274d40-70c2-46e6-9b62-e28ecb9c2556)

#### Additional
Using this package I realized that many references to your package were wrong and now you can install the package through composer and display the badge data correctly 😄. Thanks for the work to merge all the pr on hold in the original project and make this package more usable.
